### PR TITLE
Added possibility for mapping one type to another

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -108,7 +108,7 @@ func Subtract[T Ordered](s1, s2 []T) []T {
 }
 
 type MapFunc[T any] interface {
-	func(int, T) T | func(T) T
+	~func(int, T) T | ~func(T) T
 }
 
 // Map over each element in the slice and perform an operation on it. the result of the operation will replace the element value.

--- a/slice.go
+++ b/slice.go
@@ -37,7 +37,7 @@ func Sort[T Ordered](ss []T) []T {
 	}
 	ss2 := make([]T, len(ss))
 	copy(ss2, ss)
-	sort.Slice(ss2, func(i int, j int) bool{
+	sort.Slice(ss2, func(i int, j int) bool {
 		return ss2[i] <= ss2[j]
 	})
 	return ss2
@@ -107,18 +107,19 @@ func Subtract[T Ordered](s1, s2 []T) []T {
 	return result
 }
 
+type MapFunc[T any] interface {
+	func(int, T) T | func(T) T
+}
+
 // Map over each element in the slice and perform an operation on it. the result of the operation will replace the element value.
 // Normal func structure is func(i int, s string) string.
 // Also accepts func structure func(s string) string
-func Map[T any](ss []T, funcInterface interface{}) []T {
+func Map[T any, F MapFunc[T]](ss []T, funcInterface F) []T {
 	if ss == nil {
 		return nil
 	}
-	if funcInterface == nil {
-		return ss
-	}
 	f := func(i int, s T) T {
-		switch tf := funcInterface.(type) {
+		switch tf := (interface{})(funcInterface).(type) {
 		case func(int, T) T:
 			return tf(i, s)
 		case func(T) T:
@@ -170,7 +171,6 @@ func SortedIndex[T Ordered](ss []T, s T) int {
 	return -1
 }
 
-
 // First returns the First element, or "" if there are no elements in the slice.
 // First will also return an "ok" bool value that will be false if there were no elements to select from
 func First[T any](ss []T) (T, bool) {
@@ -189,9 +189,13 @@ func Last[T any](ss []T) (T, bool) {
 	return *new(T), false
 }
 
-func Select[T any](ss []T, funcInterface interface{}) []T {
+type SelectFunc[T any] interface {
+	~func(int, T) bool | ~func(T) bool
+}
+
+func Select[T any, F SelectFunc[T]](ss []T, funcInterface F) []T {
 	f := func(i int, s T) bool {
-		switch tf := funcInterface.(type) {
+		switch tf := (interface{})(funcInterface).(type) {
 		case func(int, T) bool:
 			return tf(i, s)
 		case func(T) bool:
@@ -226,7 +230,7 @@ func SortedContains[T Ordered](ss []T, s T) bool {
 func Pop[T any](ss []T) (T, []T) {
 	elem, ok := Last(ss)
 	if ok {
-		return elem, ss[0:len(ss)-1]
+		return elem, ss[0 : len(ss)-1]
 	}
 
 	return elem, nil
@@ -246,10 +250,14 @@ func Unshift[T any](ss []T, elem T) []T {
 	return append([]T{elem}, ss...)
 }
 
+type FindFunc[T any] interface {
+	~func(T) bool | ~func(int, T) bool
+}
+
 // Find and return the first element that matches. returns false if none found.
-func Find[T any](ss []T, funcInterface interface{}) (elem T, found bool) {
+func Find[T any, F FindFunc[T]](ss []T, funcInterface F) (elem T, found bool) {
 	f := func(i int, s T) bool {
-		switch tf := funcInterface.(type) {
+		switch tf := (interface{})(funcInterface).(type) {
 		case func(int, T) bool:
 			return tf(i, s)
 		case func(T) bool:

--- a/slice.go
+++ b/slice.go
@@ -107,27 +107,27 @@ func Subtract[T Ordered](s1, s2 []T) []T {
 	return result
 }
 
-type MapFunc[T any] interface {
-	~func(int, T) T | ~func(T) T
+type MapFunc[T any, R any] interface {
+	~func(int, T) R | ~func(T) R
 }
 
 // Map over each element in the slice and perform an operation on it. the result of the operation will replace the element value.
 // Normal func structure is func(i int, s string) string.
 // Also accepts func structure func(s string) string
-func Map[T any, F MapFunc[T]](ss []T, funcInterface F) []T {
+func Map[T any, R any, F MapFunc[T, R]](ss []T, funcInterface F) []R {
 	if ss == nil {
 		return nil
 	}
-	f := func(i int, s T) T {
+	f := func(i int, s T) R {
 		switch tf := (interface{})(funcInterface).(type) {
-		case func(int, T) T:
+		case func(int, T) R:
 			return tf(i, s)
-		case func(T) T:
+		case func(T) R:
 			return tf(s)
 		}
 		panic(fmt.Sprintf("Map cannot understand function type %T", funcInterface))
 	}
-	result := make([]T, len(ss))
+	result := make([]R, len(ss))
 	for i, s := range ss {
 		result[i] = f(i, s)
 	}

--- a/slice_test.go
+++ b/slice_test.go
@@ -31,16 +31,17 @@ func TestUnique(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	s := []string{"a", "b", "c"}
-	result := slice.Map(s, func(i int, s string) string {
+	result := slice.Map[string, string](s, func(i int, s string) string {
 		return strings.ToUpper(s)
 	})
 	expected := []string{"A", "B", "C"}
 
 	require.Equal(t, expected, result)
 
-	require.Equal(t, []string{"FISH"}, slice.Map([]string{"fish"}, strings.ToUpper))
-	require.Equal(t, []string{"fish"}, slice.Map([]string{" fish "}, strings.TrimSpace))
+	require.Equal(t, []string{"FISH"}, slice.Map[string, string]([]string{"fish"}, strings.ToUpper))
+	require.Equal(t, []string{"fish"}, slice.Map[string, string]([]string{" fish "}, strings.TrimSpace))
 
+	require.Equal(t, []int{4}, slice.Map[string, int]([]string{"fish"}, func(s string) int { return len(s) }))
 }
 
 func TestReduce(t *testing.T) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -38,11 +38,6 @@ func TestMap(t *testing.T) {
 
 	require.Equal(t, expected, result)
 
-	var nilStringSlice []string
-	require.Equal(t, []string(nil), slice.Map(nilStringSlice, nil))
-	require.Equal(t, []string{}, slice.Map([]string{}, nil))
-	require.Equal(t, []string{"a"}, slice.Map([]string{"a"}, nil))
-
 	require.Equal(t, []string{"FISH"}, slice.Map([]string{"fish"}, strings.ToUpper))
 	require.Equal(t, []string{"fish"}, slice.Map([]string{" fish "}, strings.TrimSpace))
 


### PR DESCRIPTION
> Proposal

Changed signature of Map to 
`func Map[T any, R any](s []T, func (item T) R ) []R`
Now we have possibility to map one type to another
**BUT**
Current golang version cannot infer R
```
// WRONG:
// cannot infer R compilerErrorCode(138)
require.Equal(t, []int{4}, slice.Map([]string{"fish"}, func(s string) int { return len(s) }))
// CORRECT
require.Equal(t, []int{4}, slice.Map[string, int]([]string{"fish"}, func(s string) int { return len(s) }))
```
